### PR TITLE
Fix Qdrant vector store initialization error

### DIFF
--- a/src/core/data/db/qdrant/config.py
+++ b/src/core/data/db/qdrant/config.py
@@ -31,6 +31,6 @@ class QdrantSingleton:
             cls._instance = QdrantVectorStore(
                 client=qdrant_client,
                 collection_name=settings.qdrant.collection_name,
-                embeddings=cls._get_embeddings(settings),
+                embedding=cls._get_embeddings(settings),
             )
         return cls._instance


### PR DESCRIPTION
## Summary
- pass the embedding model to `QdrantVectorStore` using the supported `embedding` keyword

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e587f732e4832fa3297fb0ac2abe55