### PR TITLE
Ensure Qdrant collection exists before use

### DIFF
--- a/src/core/data/db/qdrant/config.py
+++ b/src/core/data/db/qdrant/config.py
@@ -1,6 +1,7 @@
 from langchain_ollama import OllamaEmbeddings
 from langchain_qdrant import QdrantVectorStore
 from qdrant_client import QdrantClient
+from qdrant_client.http import models as qdrant_models
 
 from src.config import Settings, SettingsSingleton
 
@@ -28,9 +29,39 @@ class QdrantSingleton:
                 api_key=settings.qdrant.api_key,
             )
 
+            embeddings = cls._get_embeddings(settings)
+            cls._ensure_collection_exists(qdrant_client, settings, embeddings)
+
             cls._instance = QdrantVectorStore(
                 client=qdrant_client,
                 collection_name=settings.qdrant.collection_name,
-                embeddings=cls._get_embeddings(settings),
+                embedding=embeddings,
             )
         return cls._instance
+
+    @classmethod
+    def _ensure_collection_exists(
+        cls,
+        client: QdrantClient,
+        settings: Settings,
+        embeddings: OllamaEmbeddings,
+    ) -> None:
+        collection_name = settings.qdrant.collection_name
+        if client.collection_exists(collection_name=collection_name):
+            return
+
+        vector_size = cls._get_vector_size(embeddings)
+        client.create_collection(
+            collection_name=collection_name,
+            vectors_config=qdrant_models.VectorParams(
+                size=vector_size,
+                distance=qdrant_models.Distance.COSINE,
+            ),
+        )
+
+    @staticmethod
+    def _get_vector_size(embeddings: OllamaEmbeddings) -> int:
+        sample_embedding = embeddings.embed_query("vector size probe")
+        if not sample_embedding:
+            raise ValueError("Failed to determine embedding dimensionality")
+        return len(sample_embedding)


### PR DESCRIPTION
## Summary
- pass the embedding model to `QdrantVectorStore` using the supported `embedding` keyword
- create the configured Qdrant collection if it does not exist before instantiating the vector store

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e587f732e4832fa3297fb0ac2abe55